### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1,32 +1,32 @@
-# Using the BitPay Python Client Library
+# Using the GloBee Python Client Library
 
 
 ## Prerequisites
-You must have BitPay or test.bitpay merchant account to use this library. [Signing up for a merchant account](https://bitpay.com/start) is free.
+You must have GloBee or test.globee merchant account to use this library. [Signing up for a merchant account](https://globee.com/register) is free.
 
 ## Quick Start
 ### Installation
 
-BitPay's python library was developed in Python 3.4.2. The recommended method of installion is using pip.
+GloBee's python library was developed in Python 3.4.2. The recommended method of installion is using pip.
 
-`pip install 'bitpay-py2'`
+`pip install 'globee-py2'`
 
 ### Basic Usage
 
-The bitpay library allows authenticating with BitPay, creating invoices, and retrieving invoices.
+The globee library allows authenticating with GloBee, creating invoices, and retrieving invoices.
   
-#### Pairing with Bitpay.com
+#### Pairing with GloBee.com
 
-Before pairing with BitPay.com, you'll need to log in to your BitPay account and navigate to /api-tokens. Generate a new pairing code and use it in the next step. You can try out various functions using the Python REPL. In this example, it's assumed that we are working against the bitpay test server and have generated the pairing code "abcdefg".
+Before pairing with GloBee.com, you'll need to log in to your GloBee account and navigate to /api-tokens. Generate a new pairing code and use it in the next step. You can try out various functions using the Python REPL. In this example, it's assumed that we are working against the globee test server and have generated the pairing code "abcdefg".
 
     > from bitpay.bitpay_client import Client
-    > client = Client(api_uri="https://test.bitpay.com") #if api_uri is not passed, it defaults to "https://bitpay.com"
+    > client = Client(api_uri="https://test.globee.com") #if api_uri is not passed, it defaults to "https://globee.com"
     > client.pair_pos_client("abcdefg")
 
 To perform a second pairing method - client-side pairing - you will need to specify the facade you want to create and call create_token(). The JSON response will include a pairing code to append to the end of the API access request URL specified in the documentation.  For example, if you wanted to create a token for the merchant facade:
 
     > from bitpay.bitpay_client import Client
-    > client = Client(api_uri="https://test.bitpay.com")
+    > client = Client(api_uri="https://test.globee.com")
     > client.create_token("merchant")
 
 The response will include the pairing code which you'll use for the access request URL:
@@ -37,9 +37,9 @@ The response will include the pairing code which you'll use for the access reque
 ['xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'], 'method': 'inactive'}], 'facade': 'merchant'}]}
 ```
 
-So in the example above, the URL would look like this: http://test.bitpay.com/api-access-request?pairingCode=AAAAAA
+So in the example above, the URL would look like this: http://test.globee.com/api-access-request?pairingCode=AAAAAA
 
-When you nagivate to this address, you will be prompted to approve this request.  Once approved, you can use the token returned to perform any API calls needed.  To learn more about this method, see the [BitPay REST API documentation](https://bitpay.com/api#facades) for details.
+When you nagivate to this address, you will be prompted to approve this request.  Once approved, you can use the token returned to perform any API calls needed.  To learn more about this method, see the [GloBee REST API documentation](https://globee.com/api-docs#facades) for details.
 
 #### To create an invoice with a paired client:
 
@@ -47,5 +47,5 @@ Using the same web client from the last step:
 
     > client.create_invoice({"price": 20, "currency": "USD", "token": client.tokens['pos']})
 
-That will return the invoice as JSON. Other parameters can be sent, see the [BitPay REST API documentation](https://bitpay.com/api#resource-Invoices) for details.
+That will return the invoice as JSON. Other parameters can be sent, see the [GloBee REST API documentation](https://globee.com/api-docs#resource-Invoices) for details.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# GloBee Library for Python 2
+# BitPay Library for Python 2
 
-Powerful, flexible, lightweight interface to the cryptographically secure GloBee Bitcoin & Altcoin Payment Gateway API.
+Powerful, flexible, lightweight interface to the cryptographically secure BitPay Bitcoin Payment Gateway API.
 
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://raw.githubusercontent.com/bitpay/bitpay-python-py2/master/LICENSE.txt)
 [![Travis](https://img.shields.io/travis/bitpay/bitpay-python-py2.svg?style=flat-square)](https://travis-ci.org/bitpay/bitpay-python-py2)
@@ -10,24 +10,24 @@ Powerful, flexible, lightweight interface to the cryptographically secure GloBee
 [![Scrutinizer](https://img.shields.io/scrutinizer/g/bitpay/bitpay-python-py2.svg?style=flat-square)](https://scrutinizer-ci.com/g/bitpay/bitpay-python-py2/)
 [![Coveralls](https://img.shields.io/coveralls/bitpay/bitpay-python-py2.svg?style=flat-square)](https://coveralls.io/r/bitpay/bitpay-python-py2)
 
-This library is only compatible with Python 2. If you're using Python 3.x, please use our separate [bitpay-python](https://github.com/GloBee-Official/bitpay-python) library.
+This library is only compatible with Python 2. If you're using Python 3.x, please use our separate [bitpay-python](https://github.com/ionux/bitpay-python) library.
 
 ## Getting Started
 To get up and running with this library quickly, see these getting started guides:
-* https://github.com/GloBee-Official/bitpay-python-py2/blob/master/GUIDE.md
+* https://github.com/bitpay/bitpay-python-py2/blob/master/GUIDE.md
 * https://support.bitpay.com/hc/en-us/articles/115003001203-How-do-I-configure-and-use-the-BitPay-Python-Library-
 * https://bitpay.com/docs/testing
 
 ## API Documentation
 
-API Documentation is available on the [GloBee site](https://globee.com/api-docs).
+API Documentation is available on the [BitPay site](https://bitpay.com/api).
 
 ## Running the Tests
 
-Before running the behavior tests, you will need a test.globee.com account and you will need to set the local constants.
+Before running the behavior tests, you will need a test.bitpay.com account and you will need to set the local constants.
 
 To set constants:
-    > source tasks/set_constants.sh "https://test.globee.com" your@email yourpassword
+    > source tasks/set_constants.sh "https://test.bitpay.com" your@email yourpassword
 
 To run unit tests:
     > nosetests
@@ -39,12 +39,12 @@ To run behavior tests:
 
 Let us know! Send a pull request or a patch. Questions? Ask! We're here to help. We will respond to all filed issues.
 
-**GloBee Support:**
+**BitPay Support:**
 
-* [GitHub Issues](https://github.com/GloBee-Official/bitpay-python-py2/issues)
+* [GitHub Issues](https://github.com/bitpay/bitpay-python-py2/issues)
   * Open an issue if you are having issues with this library
-* [Support](https://globee.com)
-  * GloBee merchant support documentation
+* [Support](https://help.bitpay.com)
+  * BitPay merchant support documentation
 
 Sometimes a download can become corrupted for various reasons.  However, you can verify that the release package you downloaded is correct by checking the md5 checksum "fingerprint" of your download against the md5 checksum value shown on the Releases page.  Even the smallest change in the downloaded release package will cause a different value to be shown!
   * If you are using Windows, you can download a checksum verifier tool and instructions directly from Microsoft here: http://www.microsoft.com/en-us/download/details.aspx?id=11533

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Powerful, flexible, lightweight interface to the cryptographically secure GloBee
 
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://raw.githubusercontent.com/bitpay/bitpay-python-py2/master/LICENSE.txt)
 [![Travis](https://img.shields.io/travis/bitpay/bitpay-python-py2.svg?style=flat-square)](https://travis-ci.org/bitpay/bitpay-python-py2)
-[![Latest Version](https://pypip.in/version/bitpay_py2/badge.svg?style=flat-square)](https://pypi.python.org/pypi/bitpay-py2/)
-[![Supported Python versions](https://pypip.in/py_versions/bitpay_py2/badge.svg?style=flat-square)](https://pypi.python.org/pypi/bitpay-py2/)
+[![Latest Version](https://img.shields.io/pypi/v/bitpay_py2.svg?style=flat-square)](https://pypi.python.org/pypi/bitpay-py2/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/bitpay_py2.svg?style=flat-square)](https://pypi.python.org/pypi/bitpay-py2/)
 [![Code Climate](https://img.shields.io/codeclimate/github/bitpay/bitpay-python-py2.svg?style=flat-square)](https://codeclimate.com/github/bitpay/bitpay-python-py2)
 [![Scrutinizer](https://img.shields.io/scrutinizer/g/bitpay/bitpay-python-py2.svg?style=flat-square)](https://scrutinizer-ci.com/g/bitpay/bitpay-python-py2/)
 [![Coveralls](https://img.shields.io/coveralls/bitpay/bitpay-python-py2.svg?style=flat-square)](https://coveralls.io/r/bitpay/bitpay-python-py2)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# BitPay Library for Python 2
+# GloBee Library for Python 2
 
-Powerful, flexible, lightweight interface to the cryptographically secure BitPay Bitcoin Payment Gateway API.
+Powerful, flexible, lightweight interface to the cryptographically secure GloBee Bitcoin & Altcoin Payment Gateway API.
 
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://raw.githubusercontent.com/bitpay/bitpay-python-py2/master/LICENSE.txt)
 [![Travis](https://img.shields.io/travis/bitpay/bitpay-python-py2.svg?style=flat-square)](https://travis-ci.org/bitpay/bitpay-python-py2)
@@ -10,24 +10,24 @@ Powerful, flexible, lightweight interface to the cryptographically secure BitPay
 [![Scrutinizer](https://img.shields.io/scrutinizer/g/bitpay/bitpay-python-py2.svg?style=flat-square)](https://scrutinizer-ci.com/g/bitpay/bitpay-python-py2/)
 [![Coveralls](https://img.shields.io/coveralls/bitpay/bitpay-python-py2.svg?style=flat-square)](https://coveralls.io/r/bitpay/bitpay-python-py2)
 
-This library is only compatible with Python 2. If you're using Python 3.x, please use our separate [bitpay-python](https://github.com/ionux/bitpay-python) library.
+This library is only compatible with Python 2. If you're using Python 3.x, please use our separate [bitpay-python](https://github.com/GloBee-Official/bitpay-python) library.
 
 ## Getting Started
 To get up and running with this library quickly, see these getting started guides:
-* https://github.com/bitpay/bitpay-python-py2/blob/master/GUIDE.md
+* https://github.com/GloBee-Official/bitpay-python-py2/blob/master/GUIDE.md
 * https://support.bitpay.com/hc/en-us/articles/115003001203-How-do-I-configure-and-use-the-BitPay-Python-Library-
 * https://bitpay.com/docs/testing
 
 ## API Documentation
 
-API Documentation is available on the [BitPay site](https://bitpay.com/api).
+API Documentation is available on the [GloBee site](https://globee.com/api-docs).
 
 ## Running the Tests
 
-Before running the behavior tests, you will need a test.bitpay.com account and you will need to set the local constants.
+Before running the behavior tests, you will need a test.globee.com account and you will need to set the local constants.
 
 To set constants:
-    > source tasks/set_constants.sh "https://test.bitpay.com" your@email yourpassword
+    > source tasks/set_constants.sh "https://test.globee.com" your@email yourpassword
 
 To run unit tests:
     > nosetests
@@ -39,12 +39,12 @@ To run behavior tests:
 
 Let us know! Send a pull request or a patch. Questions? Ask! We're here to help. We will respond to all filed issues.
 
-**BitPay Support:**
+**GloBee Support:**
 
-* [GitHub Issues](https://github.com/bitpay/bitpay-python-py2/issues)
+* [GitHub Issues](https://github.com/GloBee-Official/bitpay-python-py2/issues)
   * Open an issue if you are having issues with this library
-* [Support](https://help.bitpay.com)
-  * BitPay merchant support documentation
+* [Support](https://globee.com)
+  * GloBee merchant support documentation
 
 Sometimes a download can become corrupted for various reasons.  However, you can verify that the release package you downloaded is correct by checking the md5 checksum "fingerprint" of your download against the md5 checksum value shown on the Releases page.  Even the smallest change in the downloaded release package will cause a different value to be shown!
   * If you are using Windows, you can download a checksum verifier tool and instructions directly from Microsoft here: http://www.microsoft.com/en-us/download/details.aspx?id=11533

--- a/bitpay/bitpay_client.py
+++ b/bitpay/bitpay_client.py
@@ -7,7 +7,7 @@ import re
 
 class Client:
 
-    def __init__(self, api_uri="https://bitpay.com", insecure=False,
+    def __init__(self, api_uri="https://globee.com", insecure=False,
                  pem=key_utils.generate_pem(), tokens={}):
 
         self.uri = api_uri
@@ -15,12 +15,12 @@ class Client:
         self.pem = pem
         self.client_id = key_utils.get_sin_from_pem(pem)
         self.tokens = tokens
-        self.user_agent = 'bitpay-python'
+        self.user_agent = 'globee-python'
 
     def pair_pos_client(self, code):
         """
         POST /tokens
-        https://bitpay.com/api#resource-Tokens
+        https://globee.com/api-docs#resource-Tokens
         """
         if re.match("^\w{7,7}$", code) is None:
             raise BitPayArgumentError("pairing code is not legal")
@@ -40,7 +40,7 @@ class Client:
     def create_token(self, facade):
         """
         POST /tokens
-        https://bitpay.com/api#resource-Tokens
+        https://globee.com/api-docs#resource-Tokens
         """
         payload = {'id': self.client_id, 'facade': facade}
         headers = {"content-type": "application/json",
@@ -58,7 +58,7 @@ class Client:
     def create_invoice(self, params):
         """
         POST /invoices
-        https://bitpay.com/api#resource-Invoices
+        https://globee.com/api-docs#resource-Invoices
         """
         self.verify_invoice_params(params['price'], params['currency'])
         payload = json.dumps(params)
@@ -80,7 +80,7 @@ class Client:
     def get_invoice(self, invoice_id):
         """
         GET /invoices/:invoiceId
-        https://bitpay.com/api#resource-Invoices
+        https://globee.com/api-docs#resource-Invoices
         """
         uri = self.uri + "/invoices/" + invoice_id
         try:
@@ -94,7 +94,7 @@ class Client:
     def verify_tokens(self):
         """
         GET /tokens
-        https://bitpay.com/api#resource-Tokens
+        https://globee.com/api-docs-docs#resource-Tokens
         """
         xidentity = key_utils.get_compressed_public_key_from_pem(self.pem)
         xsignature = key_utils.sign(self.uri + "/tokens", self.pem)

--- a/examples/test.py
+++ b/examples/test.py
@@ -7,8 +7,8 @@ import json
 import re
 import os.path
 
-#API_HOST = "https://bitpay.com" #for production, live bitcoin
-API_HOST = "https://test.bitpay.com" #for testing, testnet bitcoin
+#API_HOST = "https://globee.com" #for production, live bitcoin
+API_HOST = "https://test.globee.com" #for testing, testnet bitcoin
 KEY_FILE = "/tmp/key.priv"
 TOKEN_FILE = "/tmp/token.priv"
 
@@ -31,14 +31,14 @@ f.close()
 if token == "":
     client = Client(API_HOST, False, key)
     pairingCode = client.create_token("merchant")
-    print "Please go to:  %s/dashboard/merchant/api-tokens  then enter \"%s\" then click the \"Find\" button, then click \"Approve\"" % (API_HOST, pairingCode)
+    print "Please go to:  %s/dashboard/merchant/api-docs-tokens  then enter \"%s\" then click the \"Find\" button, then click \"Approve\"" % (API_HOST, pairingCode)
     raw_input("When you've complete the above, hit enter to continue...")
     print "token is: %s" % client.tokens['merchant']
     f = open(TOKEN_FILE, 'w')
     f.write(client.tokens['merchant'])
     f.close()
 else:
-    print "Creating a bitpay client using existing tokens and private key from disk."
+    print "Creating a globee client using existing tokens and private key from disk."
     client = Client(API_HOST, False, key, {'merchant': token})
 
 print "Now we assume that the pairing code that we generated along with the crypto keys is paired with your merchant account"
@@ -77,7 +77,7 @@ def get_stuff_from_bitpays_restful_api(client, uri, token):
 
 """
 GET /settlements
-https://bitpay.com/api#resource-Settlements
+https://globee.com/api-docs#resource-Settlements
 """
 settlements = get_stuff_from_bitpays_restful_api(client, client.uri + "/settlements/", token)
 pp.pprint("These are your settlements: %s" % settlements)
@@ -86,7 +86,7 @@ pp.pprint("These are your settlements: %s" % settlements)
 print "Now that we have settlements, let's do ledger pages..."
 """
 GET /ledgers
-https://bitpay.com/api#resource-Ledgers
+https://globee.com/api-docs#resource-Ledgers
 """
 ledgers = get_stuff_from_bitpays_restful_api(client, client.uri + "/ledgers/", token)
 pp.pprint("These are your ledgers: %s" % ledgers)

--- a/examples/test_merchant_facade.py
+++ b/examples/test_merchant_facade.py
@@ -7,8 +7,8 @@ import json
 import re
 import os.path
 
-#API_HOST = "https://bitpay.com" #for production, live bitcoin
-API_HOST = "https://test.bitpay.com" #for testing, testnet bitcoin
+#API_HOST = "https://globee.com" #for production, live bitcoin
+API_HOST = "https://test.globee.com" #for testing, testnet bitcoin
 KEY_FILE = "/tmp/key.priv"
 TOKEN_FILE = "/tmp/token.priv"
 
@@ -17,7 +17,7 @@ if os.path.isfile(KEY_FILE):
     f = open(KEY_FILE, 'r')
     key = f.read()
     f.close()
-    print("Creating a bitpay client using existing private key from disk.")
+    print("Creating a globee client using existing private key from disk.")
 else:
     key = bku.generate_pem()
     f = open(KEY_FILE, 'w')

--- a/examples/test_payouts.py
+++ b/examples/test_payouts.py
@@ -7,8 +7,8 @@ import json
 import re
 import os.path
 
-#API_HOST = "https://bitpay.com" #for production, live bitcoin
-API_HOST = "https://test.bitpay.com" #for testing, testnet bitcoin
+#API_HOST = "https://globee.com" #for production, live bitcoin
+API_HOST = "https://test.globee.com" #for testing, testnet bitcoin
 KEY_FILE = "/tmp/key.priv"
 TOKEN_FILE = "/tmp/token.priv"
 pp = pprint.PrettyPrinter(indent=4)
@@ -18,7 +18,7 @@ if os.path.isfile(KEY_FILE):
     f = open(KEY_FILE, 'r')
     key = f.read()
     f.close()
-    print("Creating a bitpay client using existing private key from disk.")
+    print("Creating a globee client using existing private key from disk.")
 else:
     key = bku.generate_pem()
     f = open(KEY_FILE, 'w')
@@ -90,6 +90,6 @@ print("Creating a payout batch now")
 print("token = " + token)
 # posting a payout batch
 params = {"token":token, "notificationURL":"http://test.merchant.com/IPNlogger.php", "notificationEmail":"test@merchant.com", "effectiveDate":"2017-08-23", "amount":"400","currency":"USD","instructions":[ {"label":"Test1","address":"mzDTjhkfJfatXHRUWKcE2BXxHt4Pfz2PK7","amount":"300"},{"label":"Test2","address":"mfadguj41aYgEwPATAFnkKcKQNqhpNTrdi","amount":"100"}]}
-payoutBatch = post_to_bitpay_api(client, "https://test.bitpay.com", "payouts", params)
+payoutBatch = post_to_bitpay_api(client, "https://test.globee.com", "payouts", params)
 pp.pprint(payoutBatch)
 

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,18 @@
 # coding=utf-8
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 setup(
-    name="bitpay-py2",
+    name="globee-py2",
     packages=["bitpay"],
     version="2.3.5",
-    description="Accept bitcoin with BitPay",
-    author="BitPay Integrations Team",
-    author_email="integrations@bitpay.com",
-    url="https://github.com/bitpay/bitpay-python-py2",
-    download_url="https://github.com/bitpay/bitpay-python-py2/tarball/v2.3.5",
-    keywords=["bitcoin", "payments", "crypto"],
+    description="Accept bitcoin and altcoins with GloBee",
+    author="GloBee Integrations Team",
+    author_email="integrations@globee.com",
+    url="https://github.com/GloBee-Official/bitpay-python-py2",
+    download_url="https://github.com/GloBee-Official/bitpay-python-py2/tarball/v2.3.5",
+    keywords=["bitcoin", "payments", "crypto", "altcoin"],
     license="MIT License",
     classifiers=["Programming Language :: Python",
                  "Programming Language :: Python :: 2.7",
@@ -28,11 +31,11 @@ Python Library for integrating with BitPay
 This library is compatible with Python 2.7.8. It is not compatible with Python 3.
 
 This library is a simple way to integrate your application with
-BitPay for taking bitcoin payments. It exposes three basic
-functions, authenticating with bitpay, creating invoices,
+GloBee for accepting bitcoin and altcoin payments. It exposes three basic
+functions, authenticating with globee, creating invoices,
 and retrieving invoices. It is not meant as a replacement for
-the entire BitPay API. However, the key_utils module contains
-all of the tools you need to use the BitPay API for other
+the entire GloBee API. However, the key_utils module contains
+all of the tools you need to use the GloBee API for other
 purposes.
 
 © 2015 BitPay, Inc.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20bitpay-py2))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `bitpay-py2`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.