### PR TITLE
Manually switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Powerful, flexible, lightweight interface to the cryptographically secure BitPay
 
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://raw.githubusercontent.com/bitpay/bitpay-python-py2/master/LICENSE.txt)
 [![Travis](https://img.shields.io/travis/bitpay/bitpay-python-py2.svg?style=flat-square)](https://travis-ci.org/bitpay/bitpay-python-py2)
-[![Latest Version](https://pypip.in/version/bitpay_py2/badge.svg?style=flat-square)](https://pypi.python.org/pypi/bitpay-py2/)
-[![Supported Python versions](https://pypip.in/py_versions/bitpay_py2/badge.svg?style=flat-square)](https://pypi.python.org/pypi/bitpay-py2/)
+[![Latest Version](https://img.shields.io/pypi/v/bitpay_py2.svg?style=flat-square)](https://pypi.python.org/pypi/bitpay-py2/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/bitpay_py2.svg?style=flat-square)](https://pypi.python.org/pypi/bitpay-py2/)
 [![Code Climate](https://img.shields.io/codeclimate/github/bitpay/bitpay-python-py2.svg?style=flat-square)](https://codeclimate.com/github/bitpay/bitpay-python-py2)
 [![Scrutinizer](https://img.shields.io/scrutinizer/g/bitpay/bitpay-python-py2.svg?style=flat-square)](https://scrutinizer-ci.com/g/bitpay/bitpay-python-py2/)
 [![Coveralls](https://img.shields.io/coveralls/bitpay/bitpay-python-py2.svg?style=flat-square)](https://coveralls.io/r/bitpay/bitpay-python-py2)


### PR DESCRIPTION
Same as #15, except performed manually to avoid problems.
Sorry for the hassle of the broken pull request.